### PR TITLE
Fix trade was not matching sometimes at max amount

### DIFF
--- a/atomic_qt_design/qml/Exchange/Trade/Trade.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/Trade.qml
@@ -117,12 +117,13 @@ Item {
         updateTradeInfo()
     }
 
-    function updateTradeInfo() {
+    function updateTradeInfo(force=false) {
         const base = getTicker(true)
         const rel = getTicker(false)
         const amount = form_base.getVolume()
-        if(base !== undefined && rel !== undefined && amount !== undefined &&
-           base !== ''        && rel !== ''        && amount !== '' && amount !== '0') {
+        if(force ||
+            (base !== undefined && rel !== undefined && amount !== undefined &&
+             base !== ''        && rel !== ''        && amount !== '' && amount !== '0')) {
             getTradeInfo(base, rel, amount)
         }
     }
@@ -229,7 +230,9 @@ Item {
     }
 
     function trade(base, rel) {
-        form_base.capVolume()
+        updateTradeInfo(true) // Force update trade info
+        form_base.capVolume() // To cap the value for one last time
+
         action_result = API.get().place_sell_order(base, rel, getCurrentPrice(), form_base.field.text) ? "success" : "error"
         if(action_result === "success") {
             onOrderSuccess()


### PR DESCRIPTION
I'm not completely sure if it's the correct fix. But I assume that problem is caused by fees changing and max amount with fees dropped is being outdated until user clicks the trade button. 

Solution for this is to cap the amount once more right before `place_sell_order` is called. 

Here is my test:

![image](https://user-images.githubusercontent.com/6732486/78451169-7f368580-768c-11ea-937d-29978f53afbc.png)

![image](https://user-images.githubusercontent.com/6732486/78451176-88bfed80-768c-11ea-9995-d7b37159e76d.png)

