### PR TITLE
Fix trade input was resetting to max balance on rel ticker change

### DIFF
--- a/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
@@ -149,9 +149,14 @@ Rectangle {
         input_volume.field.text = getMaxTradableVolume(true)
     }
 
-    function reset() {
+    function reset(is_base) {
         if(my_side) {
-            setMax()
+            // is_base info comes from the ComboBox ticker change in OrderForm.
+            // At other places it's not given.
+            // We don't want to reset base balance at rel ticker change
+            // Therefore it will reset only if this info is set from ComboBox -> setPair
+            // Or if it's from somewhere else like page change, in that case is_base is undefined
+            if(is_base === undefined || is_base) setMax()
         }
         else {
             input_volume.field.text = ''
@@ -220,7 +225,7 @@ Rectangle {
                 model: ticker_list
                 onCurrentTextChanged: {
                     if(!recursive_update) {
-                        setPair()
+                        setPair(my_side)
                         if(my_side) prev_base = getTicker()
                         else prev_rel = getTicker()
                         updateForms(my_side, combo.currentText)

--- a/atomic_qt_design/qml/Exchange/Trade/Trade.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/Trade.qml
@@ -22,18 +22,18 @@ Item {
     }
 
     function fullReset() {
-        reset()
+        reset(true)
         prev_base = ''
         prev_rel = ''
         curr_trade_info = default_curr_trade_info
         orderbook_timer.running = false
     }
 
-    function reset(reset_result=true) {
+    function reset(reset_result=true, is_base) {
         if(reset_result) action_result = ""
         resetPreferredPrice()
-        form_base.reset()
-        form_rel.reset()
+        form_base.reset(is_base)
+        form_rel.reset(is_base)
     }
 
     Timer {
@@ -136,7 +136,7 @@ Item {
 
     function onOpened() {
         updateOrderbook()
-        reset()
+        reset(true)
         updateForms()
     }
 
@@ -214,11 +214,11 @@ Item {
         return base !== '' && rel !== '' && base !== rel
     }
 
-    function setPair() {
+    function setPair(is_base) {
         if(getTicker(true) === getTicker(false)) swapPair()
         else {
             if(validBaseRel()) {
-                reset()
+                reset(true, is_base)
 
                 const new_base = getTicker(true)
                 API.get().set_current_orderbook(new_base)


### PR DESCRIPTION
Fixes #140 

It is a really deep and critical change. It should be tested well.

The reset still happens on page changes, but that's for protection from other potential issues. Preventing that is not important as this fix, therefore I won't take the risk of that change for now.