### PR TITLE
Unblock buttons and hide "Loading" from non-ERC20 or ETH

### DIFF
--- a/atomic_qt_design/qml/Wallet/Wallet.qml
+++ b/atomic_qt_design/qml/Wallet/Wallet.qml
@@ -138,7 +138,8 @@ RowLayout {
             }
 
             DefaultText {
-                visible: API.get().current_coin_info.tx_state !== "InProgress" && API.get().current_coin_info.transactions.length === 0
+                visible: (API.get().current_coin_info.type !== "ERC-20" ||
+                          API.get().current_coin_info.tx_state !== "InProgress") && API.get().current_coin_info.transactions.length === 0
                 text: API.get().empty_string + (qsTr("No transactions"))
                 font.pixelSize: Style.textSize
                 color: Style.colorWhite4
@@ -150,7 +151,7 @@ RowLayout {
             Rectangle {
                 id: loading_tx
                 color: "transparent"
-                visible: API.get().current_coin_info.tx_state === "InProgress"
+                visible: API.get().current_coin_info.type === "ERC-20" && API.get().current_coin_info.tx_state === "InProgress"
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
                 implicitHeight: 100

--- a/atomic_qt_design/qml/Wallet/Wallet.qml
+++ b/atomic_qt_design/qml/Wallet/Wallet.qml
@@ -82,7 +82,6 @@ RowLayout {
                 spacing: 50
 
                 DefaultButton {
-                    enabled: API.get().current_coin_info.tx_state !== "InProgress"
                     text: API.get().empty_string + (qsTr("Send"))
                     leftPadding: parent.width * button_margin
                     rightPadding: leftPadding
@@ -118,7 +117,7 @@ RowLayout {
                     rightPadding: leftPadding
 
                     visible: API.get().current_coin_info.is_claimable === true
-                    enabled: API.get().current_coin_info.tx_state !== "InProgress" && claim_rewards_modal.canClaim()
+                    enabled: claim_rewards_modal.canClaim()
                     onClicked: {
                         claim_rewards_modal.prepareClaimRewards()
                         claim_rewards_modal.open()


### PR DESCRIPTION
* Removes Loading/Syncing from coins which are not ETH or ERC-20
* Removes the disabling of Send & Claim Rewards buttons at syncing
