### PR TITLE
feat(mm2_persistent_datadir): DB from mm2 is now stored into datafolder

### DIFF
--- a/src/atomic.dex.mm2.config.hpp
+++ b/src/atomic.dex.mm2.config.hpp
@@ -33,6 +33,7 @@ namespace atomic_dex
         std::string userhome{std::getenv("HOME")};
 #endif
         std::string passphrase;
+        std::string dbdir{(get_atomic_dex_data_folder() / "mm2" / "DB").string()};
         std::string rpc_password{"atomic_dex_mm2_passphrase"};
     };
 
@@ -48,6 +49,7 @@ namespace atomic_dex
         cfg.userhome     = j.at("userhome").get<std::string>();
         cfg.passphrase   = j.at("passphrase").get<std::string>();
         cfg.rpc_password = j.at("rpc_password").get<std::string>();
+        cfg.dbdir        = j.at("dbdir").get<std::string>();
     }
 
     inline void
@@ -59,5 +61,6 @@ namespace atomic_dex
         j["userhome"]     = cfg.userhome;
         j["passphrase"]   = cfg.passphrase;
         j["rpc_password"] = cfg.rpc_password;
+        j["dbdir"]        = cfg.dbdir;
     }
 } // namespace atomic_dex

--- a/src/atomic.dex.utilities.hpp
+++ b/src/atomic.dex.utilities.hpp
@@ -21,6 +21,10 @@ get_atomic_dex_data_folder()
 inline fs::path
 get_atomic_dex_logs_folder()
 {
+    if (not fs::exists(get_atomic_dex_data_folder() / "logs"))
+    {
+        fs::create_directories(get_atomic_dex_data_folder() / "logs");
+    }
     return get_atomic_dex_data_folder() / "logs";
 }
 


### PR DESCRIPTION
eg:

```
.
├── config
│  ├── default.wallet
│  └── rmn.seed
├── logs
│  ├── 2020-05-18-04-14-59.log
│  ├── 2020-05-18-04-17-22.log
│  ├── 2020-05-18-04-19-12.log
│  ├── 2020-05-18-04-26-50.log
│  ├── 2020-05-18-04-27-54.log
│  ├── 2020-05-18-04-33-40.log
│  ├── 2020-05-18-04-34-53.log
│  ├── 2020-05-18-04-35-19.log
│  └── 2020-05-19-05-32-31.log
└── mm2
   └── DB
      └── cf3d6da1ab1df72e29d94bb531e56d5728f29739
         ├── GTC
         │  ├── checkval
         │  └── orders
         ├── ORDERS
         │  ├── checkval
         │  └── MY
         │     ├── checkval
         │     ├── MAKER
         │     │  └── checkval
         │     └── TAKER
         │        └── checkval
         ├── PRICES
         │  └── checkval
         ├── SWAPS
         │  ├── checkval
         │  ├── MY
         │  │  └── checkval
         │  └── STATS
         │     ├── checkval
         │     ├── MAKER
         │     │  └── checkval
         │     └── TAKER
         │        └── checkval
         ├── TRANSACTIONS
         │  └── checkval
         └── UNSPENTS
            └── checkval
```

Signed-off-by: romanszterg <rmscastle@gmail.com>