### PR TITLE
Syncing text

### DIFF
--- a/atomic_qt_design/qml/Wallet/Wallet.qml
+++ b/atomic_qt_design/qml/Wallet/Wallet.qml
@@ -139,8 +139,7 @@ RowLayout {
             }
 
             DefaultText {
-                visible: (API.get().current_coin_info.type !== "ERC-20" ||
-                          API.get().current_coin_info.tx_state !== "InProgress") && API.get().current_coin_info.transactions.length === 0
+                visible: API.get().current_coin_info.tx_state !== "InProgress" && API.get().current_coin_info.transactions.length === 0
                 text: API.get().empty_string + (qsTr("No transactions"))
                 font.pixelSize: Style.textSize
                 color: Style.colorWhite4
@@ -152,7 +151,7 @@ RowLayout {
             Rectangle {
                 id: loading_tx
                 color: "transparent"
-                visible: API.get().current_coin_info.type === "ERC-20" && API.get().current_coin_info.tx_state === "InProgress"
+                visible: API.get().current_coin_info.tx_state === "InProgress"
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
                 implicitHeight: 100
@@ -173,7 +172,7 @@ RowLayout {
                     DefaultText {
                         text: API.get().empty_string + (
                           API.get().current_coin_info.type === "ERC-20" ?
-                          (qsTr("Scanning blocks for TX History... %n blocks left", "", parseInt(API.get().current_coin_info.blocks_left))) :
+                          (qsTr("Scanning blocks for TX History... %n block(s) left", "", parseInt(API.get().current_coin_info.blocks_left))) :
                           (qsTr("Syncing TX History... %n TX(s) left", "", parseInt(API.get().current_coin_info.transactions_left)))
                         )
                         Layout.alignment: Qt.AlignHCenter

--- a/atomic_qt_design/qml/Wallet/Wallet.qml
+++ b/atomic_qt_design/qml/Wallet/Wallet.qml
@@ -171,7 +171,11 @@ RowLayout {
                     }
 
                     DefaultText {
-                        text: API.get().empty_string + (qsTr("Syncing %n TX(s)...", "", parseInt(API.get().current_coin_info.tx_current_block)))
+                        text: API.get().empty_string + (
+                          API.get().current_coin_info.type === "ERC-20" ?
+                          (qsTr("Scanning blocks for TX History... %n blocks left", "", parseInt(API.get().current_coin_info.blocks_left))) :
+                          (qsTr("Syncing TX History... %n TX(s) left", "", parseInt(API.get().current_coin_info.transactions_left)))
+                        )
                         Layout.alignment: Qt.AlignHCenter
                     }
                 }

--- a/src/atomic.dex.app.cpp
+++ b/src/atomic.dex.app.cpp
@@ -373,6 +373,13 @@ namespace atomic_dex
         if (!ec)
         {
             m_coin_info->set_tx_state(QString::fromStdString(tx_state.state));
+            if (mm2.get_coin_info(m_coin_info->get_ticker().toStdString()).is_erc_20) {
+                m_coin_info->set_blocks_left(tx_state.blocks_left);
+                std::cout << "blocks left: " << m_coin_info->get_blocks_left() << std::endl;
+            } else {
+                m_coin_info->set_txs_left(tx_state.transactions_left);
+                std::cout << "txs left: " << m_coin_info->get_txs_left() << std::endl;
+            }
             m_coin_info->set_tx_current_block(tx_state.current_block);
         }
     }

--- a/src/atomic.dex.mm2.hpp
+++ b/src/atomic.dex.mm2.hpp
@@ -50,6 +50,8 @@ namespace atomic_dex
     struct tx_state
     {
         std::string state;
+        std::size_t transactions_left;
+        std::size_t blocks_left;
         std::size_t current_block;
     };
 

--- a/src/atomic.dex.qt.current.coin.infos.cpp
+++ b/src/atomic.dex.qt.current.coin.infos.cpp
@@ -155,6 +155,32 @@ namespace atomic_dex
         emit tx_current_block_changed();
     }
 
+    unsigned int
+    atomic_dex::current_coin_info::get_txs_left() const noexcept
+    {
+        return this->selected_coin_txs_left;
+    }
+
+    void
+    atomic_dex::current_coin_info::set_txs_left(unsigned int txs) noexcept
+    {
+        this->selected_coin_txs_left = txs;
+        emit txs_left_changed();
+    }
+
+    unsigned int
+    atomic_dex::current_coin_info::get_blocks_left() const noexcept
+    {
+        return this->selected_coin_blocks_left;
+    }
+
+    void
+    atomic_dex::current_coin_info::set_blocks_left(unsigned int blocks) noexcept
+    {
+        this->selected_coin_blocks_left = blocks;
+        emit blocks_left_changed();
+    }
+
     QString
     current_coin_info::get_minimal_balance_for_asking_rewards() const noexcept
     {

--- a/src/atomic.dex.qt.current.coin.infos.hpp
+++ b/src/atomic.dex.qt.current.coin.infos.hpp
@@ -42,6 +42,8 @@ namespace atomic_dex
         Q_PROPERTY(QString explorer_url READ get_explorer_url WRITE set_explorer_url NOTIFY explorer_url_changed);
         Q_PROPERTY(QList<QObject*> transactions READ get_transactions WRITE set_transactions NOTIFY transactionsChanged)
         Q_PROPERTY(QString tx_state READ get_tx_state WRITE set_tx_state NOTIFY tx_state_changed);
+        Q_PROPERTY(unsigned int transactions_left READ get_txs_left WRITE set_txs_left NOTIFY txs_left_changed);
+        Q_PROPERTY(unsigned int blocks_left READ get_blocks_left WRITE set_blocks_left NOTIFY blocks_left_changed);
         Q_PROPERTY(unsigned int tx_current_block READ get_tx_current_block WRITE set_tx_current_block NOTIFY tx_current_block_changed);
 
       public:
@@ -54,6 +56,10 @@ namespace atomic_dex
         void                       set_tx_state(QString state) noexcept;
         [[nodiscard]] unsigned int get_tx_current_block() const noexcept;
         void                       set_tx_current_block(unsigned int block) noexcept;
+        [[nodiscard]] unsigned int get_txs_left() const noexcept;
+        void                       set_txs_left(unsigned int txs) noexcept;
+        [[nodiscard]] unsigned int get_blocks_left() const noexcept;
+        void                       set_blocks_left(unsigned int blocks) noexcept;
         [[nodiscard]] QObjectList  get_transactions() const noexcept;
         void                       set_transactions(QObjectList transactions) noexcept;
         [[nodiscard]] QString      get_ticker() const noexcept;
@@ -86,6 +92,8 @@ namespace atomic_dex
         void transactionsChanged();
         void type_changed();
         void name_changed();
+        void txs_left_changed();
+        void blocks_left_changed();
         void coinpaprika_id_changed();
 
       public:
@@ -99,6 +107,8 @@ namespace atomic_dex
         QString           selected_coin_url;
         QString           selected_coin_state;
         unsigned int      selected_coin_block;
+        unsigned int      selected_coin_txs_left;
+        unsigned int      selected_coin_blocks_left;
         QObjectList       selected_coin_transactions;
         bool              selected_coin_is_claimable;
         QString           selected_coin_minimal_balance_for_asking_rewards{"0"};


### PR DESCRIPTION
This branch includes `field_tx_exposed` branch commit.

GUI now shows Loading/Syncing/Scanning for non-ERC20 coins too.

Also instead of `current_block`, it shows `blocks_left` and `transactions_left`