### PR TITLE
feat(pricing): add btc price for backend.

### DIFF
--- a/src/atomic.dex.app.cpp
+++ b/src/atomic.dex.app.cpp
@@ -336,6 +336,14 @@ namespace atomic_dex
 
             std::error_code ec;
             auto            fiat_balance_std = paprika.get_price_in_fiat_all(m_current_fiat.toStdString(), ec);
+
+            if (!ec)
+            {
+                this->set_current_balance_fiat_all(QString::fromStdString(fiat_balance_std));
+            }
+
+            auto second_fiat_balance_std = paprika.get_price_in_fiat_all(m_second_current_fiat.toStdString(), ec);
+
             if (!ec)
             {
                 this->set_current_balance_fiat_all(QString::fromStdString(fiat_balance_std));
@@ -426,11 +434,24 @@ namespace atomic_dex
         return m_current_balance_all;
     }
 
+    QString
+    application::get_second_balance_fiat_all() const noexcept
+    {
+        return m_second_current_balance_all;
+    }
+
     void
     atomic_dex::application::set_current_balance_fiat_all(QString current_fiat_all_balance) noexcept
     {
         this->m_current_balance_all = std::move(current_fiat_all_balance);
         emit on_fiat_balance_all_changed();
+    }
+
+    void
+    application::set_second_current_balance_fiat_all(QString current_fiat_all_balance) noexcept
+    {
+        this->m_second_current_balance_all = std::move(current_fiat_all_balance);
+        emit on_second_fiat_balance_all_changed();
     }
 
     application::application(QObject* pParent) noexcept : QObject(pParent), m_coin_info(new current_coin_info(dispatcher_, this))
@@ -496,11 +517,24 @@ namespace atomic_dex
         return this->m_current_fiat;
     }
 
+    QString
+    application::get_second_current_fiat() const noexcept
+    {
+        return this->m_second_current_fiat;
+    }
+
     void
     application::set_current_fiat(QString current_fiat) noexcept
     {
         this->m_current_fiat = std::move(current_fiat);
         emit on_fiat_changed();
+    }
+
+    void
+    application::set_second_current_fiat(QString current_fiat) noexcept
+    {
+        this->m_second_current_fiat = std::move(current_fiat);
+        emit on_second_fiat_changed();
     }
 
     void

--- a/src/atomic.dex.app.hpp
+++ b/src/atomic.dex.app.hpp
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <QApplication>
-#include <QObject>
 #include <QImage>
+#include <QObject>
 #include <QSize>
 #include <QStringList>
 #include <QTranslator>
@@ -48,9 +48,12 @@ namespace atomic_dex
         Q_PROPERTY(QList<QObject*> enableable_coins READ get_enableable_coins NOTIFY enableableCoinsChanged)
         Q_PROPERTY(QObject* current_coin_info READ get_current_coin_info NOTIFY coinInfoChanged)
         Q_PROPERTY(QString fiat READ get_current_fiat WRITE set_current_fiat NOTIFY on_fiat_changed)
+        Q_PROPERTY(QString second_fiat READ get_second_current_fiat WRITE set_second_current_fiat NOTIFY on_second_fiat_changed)
         Q_PROPERTY(QString lang READ get_current_lang WRITE set_current_lang NOTIFY on_lang_changed)
         Q_PROPERTY(QString wallet_default_name READ get_wallet_default_name WRITE set_wallet_default_name NOTIFY on_wallet_default_name_changed)
         Q_PROPERTY(QString balance_fiat_all READ get_balance_fiat_all WRITE set_current_balance_fiat_all NOTIFY on_fiat_balance_all_changed)
+        Q_PROPERTY(QString second_balance_fiat_all READ get_second_balance_fiat_all WRITE set_second_current_balance_fiat_all NOTIFY
+                       on_second_fiat_balance_all_changed)
         Q_PROPERTY(QString initial_loading_status READ get_status WRITE set_status NOTIFY on_status_changed)
 
       private:
@@ -85,17 +88,21 @@ namespace atomic_dex
         QObjectList           get_enabled_coins() const noexcept;
         QObjectList           get_enableable_coins() const noexcept;
         QString               get_current_fiat() const noexcept;
+        QString               get_second_current_fiat() const noexcept;
         QString               get_current_lang() const noexcept;
         QString               get_balance_fiat_all() const noexcept;
+        QString               get_second_balance_fiat_all() const noexcept;
         QString               get_wallet_default_name() const noexcept;
         QString               get_status() const noexcept;
         Q_INVOKABLE QString   get_version() const noexcept;
 
         //! Properties Setter
         void set_current_fiat(QString current_fiat) noexcept;
+        void set_second_current_fiat(QString current_fiat) noexcept;
         void set_current_lang(const QString& current_lang) noexcept;
         void set_wallet_default_name(QString wallet_default_name) noexcept;
-        void set_current_balance_fiat_all(QString current_fiat) noexcept;
+        void set_current_balance_fiat_all(QString current_fiat_all_balance) noexcept;
+        void set_second_current_balance_fiat_all(QString current_fiat_all_balance) noexcept;
         void set_status(QString status) noexcept;
         void set_qt_app(QApplication* app) noexcept;
 
@@ -103,16 +110,16 @@ namespace atomic_dex
         void launch();
 
         //! Bind to the QML Worlds
-        Q_INVOKABLE QString get_paprika_id_from_ticker(QString ticker) const;
-        Q_INVOKABLE QString to_eth_checksum_qt(QString eth_lowercase_address) const;
-        Q_INVOKABLE QString recover_fund(QString uuid) const;
-        Q_INVOKABLE QString get_mm2_version() const;
-        Q_INVOKABLE bool mnemonic_validate(QString entropy);
-        Q_INVOKABLE QImage  get_qr_code(QString text_to_encode, QSize size);
-        Q_INVOKABLE QString get_log_folder() const;
-        Q_INVOKABLE QString get_export_folder() const;
-        Q_INVOKABLE QString retrieve_seed(const QString &wallet_name, const QString& password);
-        Q_INVOKABLE bool confirm_password(const QString &wallet_name, const QString& password);
+        Q_INVOKABLE QString     get_paprika_id_from_ticker(QString ticker) const;
+        Q_INVOKABLE QString     to_eth_checksum_qt(QString eth_lowercase_address) const;
+        Q_INVOKABLE QString     recover_fund(QString uuid) const;
+        Q_INVOKABLE QString     get_mm2_version() const;
+        Q_INVOKABLE bool        mnemonic_validate(QString entropy);
+        Q_INVOKABLE QImage      get_qr_code(QString text_to_encode, QSize size);
+        Q_INVOKABLE QString     get_log_folder() const;
+        Q_INVOKABLE QString     get_export_folder() const;
+        Q_INVOKABLE QString     retrieve_seed(const QString& wallet_name, const QString& password);
+        Q_INVOKABLE bool        confirm_password(const QString& wallet_name, const QString& password);
         Q_INVOKABLE QStringList get_available_langs() const;
         Q_INVOKABLE QObject* prepare_send(const QString& address, const QString& amount, bool max = false);
         Q_INVOKABLE QObject* prepare_send_fees(
@@ -164,9 +171,11 @@ namespace atomic_dex
         void enableableCoinsChanged();
         void coinInfoChanged();
         void on_fiat_changed();
+        void on_second_fiat_changed();
         void on_lang_changed();
         void lang_changed();
         void on_fiat_balance_all_changed();
+        void on_second_fiat_balance_all_changed();
         void on_status_changed();
         void on_wallet_default_name_changed();
         void myOrdersUpdated();
@@ -188,9 +197,11 @@ namespace atomic_dex
         QObjectList        m_enableable_coins;
         QTranslator        m_translator;
         QString            m_current_fiat{"USD"};
+        QString            m_second_current_fiat{"BTC"};
         QString            m_current_lang{QString::fromStdString(m_config.current_lang)};
         QString            m_current_status{"None"};
         QString            m_current_balance_all{"0.00"};
+        QString            m_second_current_balance_all{"0.00"};
         QString            m_current_default_wallet{""};
         current_coin_info* m_coin_info;
     };

--- a/src/atomic.dex.provider.coinpaprika.cpp
+++ b/src/atomic.dex.provider.coinpaprika.cpp
@@ -58,6 +58,7 @@ namespace
         }
         const ticker_historical_request request{.ticker_currency_id = current_coin.coinpaprika_id};
         auto                            answer = ticker_historical(request);
+        std::cout << answer.raw_result << std::endl;
         retry(answer, request, [&answer](const ticker_historical_request& request) { answer = ticker_historical(request); });
         if (answer.raw_result.find("error") == std::string::npos)
         {
@@ -68,22 +69,30 @@ namespace
     template <typename Provider>
     void
     process_provider(const atomic_dex::coin_config& current_coin, Provider& rate_providers, const std::string& fiat)
+
     {
-        const auto                    base = current_coin.coinpaprika_id;
-        const price_converter_request request{.base_currency_id = base, .quote_currency_id = fiat};
-        auto                          answer = price_converter(request);
-
-        retry(answer, request, [&answer](const price_converter_request& request) { answer = price_converter(request); });
-
-        if (answer.raw_result.find("error") == std::string::npos)
+        if (current_coin.coinpaprika_id != fiat)
         {
-            if (not answer.price.empty())
+            const auto                    base = current_coin.coinpaprika_id;
+            const price_converter_request request{.base_currency_id = base, .quote_currency_id = fiat};
+            auto                          answer = price_converter(request);
+
+            retry(answer, request, [&answer](const price_converter_request& request) { answer = price_converter(request); });
+
+            if (answer.raw_result.find("error") == std::string::npos)
             {
-                rate_providers.insert_or_assign(current_coin.ticker, answer.price);
+                if (not answer.price.empty())
+                {
+                    rate_providers.insert_or_assign(current_coin.ticker, answer.price);
+                }
             }
+            else
+                rate_providers.insert_or_assign(current_coin.ticker, "0.00");
         }
         else
-            rate_providers.insert_or_assign(current_coin.ticker, "0.00");
+        {
+            rate_providers.insert_or_assign(current_coin.ticker, "1.00");
+        }
     }
 } // namespace
 
@@ -143,6 +152,10 @@ namespace atomic_dex
                     spawn([this, cur_coin = current_coin]() { process_ticker_infos(cur_coin, this->m_ticker_infos_registry); });
                     spawn([this, cur_coin = current_coin]() { process_ticker_historical(cur_coin, this->m_ticker_historical_registry); });
                     process_provider(current_coin, m_usd_rate_providers, "usd-us-dollars");
+                    if (current_coin.ticker != "BTC")
+                    {
+                        process_provider(current_coin, m_btc_rate_providers, "btc-bitcoin");
+                    }
                     process_provider(current_coin, m_eur_rate_providers, "eur-euro");
                 }
 
@@ -278,6 +291,19 @@ namespace atomic_dex
             }
             current_price = m_eur_rate_providers.at(ticker);
         }
+        else if (fiat == "BTC")
+        {
+            if (ticker == "BTC")
+            {
+                return "1.00";
+            }
+            if (m_btc_rate_providers.find(ticker) == m_btc_rate_providers.cend())
+            {
+                ec = dextop_error::unknown_ticker_for_rate_conversion;
+                return "0.00";
+            }
+            current_price = m_btc_rate_providers.at(ticker);
+        }
 
         if (adjusted)
         {
@@ -298,6 +324,10 @@ namespace atomic_dex
         {
             process_provider(config, m_usd_rate_providers, "usd-us-dollars");
             process_provider(config, m_eur_rate_providers, "eur-euro");
+            if (evt.ticker != "BTC")
+            {
+                process_provider(config, m_btc_rate_providers, "btc-bitcoin");
+            }
             process_ticker_infos(config, m_ticker_infos_registry);
             process_ticker_historical(config, m_ticker_historical_registry);
         }
@@ -311,6 +341,10 @@ namespace atomic_dex
 
         m_usd_rate_providers.erase(config.ticker);
         m_eur_rate_providers.erase(config.ticker);
+        if (evt.ticker != "BTC")
+        {
+            m_btc_rate_providers.erase(config.ticker);
+        }
     }
 
     t_ticker_info_answer

--- a/src/atomic.dex.provider.coinpaprika.hpp
+++ b/src/atomic.dex.provider.coinpaprika.hpp
@@ -43,9 +43,10 @@ namespace atomic_dex
         mm2&                         m_mm2_instance;
         t_providers_registry         m_usd_rate_providers{};
         t_providers_registry         m_eur_rate_providers{};
+        t_providers_registry         m_btc_rate_providers{};
         t_ticker_infos_registry      m_ticker_infos_registry{};
         t_ticker_historical_registry m_ticker_historical_registry{};
-        t_supported_fiat_registry    m_supported_fiat_registry{"USD", "EUR"};
+        t_supported_fiat_registry    m_supported_fiat_registry{"USD", "EUR", "BTC"};
         std::thread                  m_provider_rates_thread;
         timed_waiter                 m_provider_thread_timer;
 


### PR DESCRIPTION
- Add btc rate providers
- Add the possibility to have a second "preferred" fiat.

Signed-off-by: romanszterg <rmscastle@gmail.com>