### PR TITLE
update mm2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,13 +45,13 @@ endif()
 ##! We fetch our dependence
 if (APPLE)
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.0.2000/mm2-8496d71cb-Darwin-Release.zip)
+            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.0.2002/mm2-3a9680fa4-Darwin-Release.zip)
 elseif (UNIX AND NOT APPLE)
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.0.2000/mm2-8496d71cb-Linux-Release.zip)
+            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.0.2002/mm2-3a9680fa4-Linux-Release.zip)
 else ()
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.0.2000/mm2-8496d71cb-Windows_NT-Release.zip)
+            URL https://github.com/KomodoPlatform/atomicDEX-API/releases/download/beta-2.0.2002/mm2-3a9680fa4-Windows_NT-Release.zip)
 endif ()
 
 FetchContent_Declare(jl777-coins


### PR DESCRIPTION
because of bug in 2.0.2000 with estimatefee call
swaps failing on some coins if this happens: https://dexapi.cipig.net/public/error.php?uuid=af7bb8e8-7b0c-43f9-837a-64e83ff238be