### PR TITLE
Fix macOS curl build

### DIFF
--- a/ci_tools_atomic_dex/README.md
+++ b/ci_tools_atomic_dex/README.md
@@ -56,6 +56,7 @@ export QT_ROOT=/Users/SatoshiNakamoto/Qt/5.14.0
 Installing curl:
 
 ```
+brew install autoconf automake libtool
 git clone https://github.com/phracker/MacOSX-SDKs.git ~/MacOSX-SDKs
 export CC=/usr/local/opt/llvm/bin/clang
 export CPPFLAGS="-isysroot $HOME/MacOSX-SDKs/MacOSX10.13.sdk/"

--- a/ci_tools_atomic_dex/README.md
+++ b/ci_tools_atomic_dex/README.md
@@ -60,6 +60,7 @@ git clone https://github.com/phracker/MacOSX-SDKs.git ~/MacOSX-SDKs
 export CC=/usr/local/opt/llvm@9/bin/clang
 export CPPFLAGS="-isysroot $HOME/MacOSX-SDKs/MacOSX10.13.sdk/"
 git clone https://github.com/curl/curl.git
+cd curl
 git checkout curl-7_70_0
 ./buildconf
 ./configure --disable-shared --enable-static --without-libidn2 -without-ssl --disable-ldap --with-darwinssl

--- a/ci_tools_atomic_dex/README.md
+++ b/ci_tools_atomic_dex/README.md
@@ -57,7 +57,7 @@ Installing curl:
 
 ```
 git clone https://github.com/phracker/MacOSX-SDKs.git ~/MacOSX-SDKs
-export CC=/usr/local/opt/llvm@9/bin/clang
+export CC=/usr/local/opt/llvm/bin/clang
 export CPPFLAGS="-isysroot $HOME/MacOSX-SDKs/MacOSX10.13.sdk/"
 git clone https://github.com/curl/curl.git
 cd curl


### PR DESCRIPTION
The current `curl` install guide is not smooth.

* Copy-pasting the snippet fails because after `git clone` there is no `cd`.
* `buildconf` fails because `autoconf` `automake` `libtool` are missing.
* c compiler is not working because it's not guaranteed to have `llvm@9` folder.
