### PR TITLE
Fix swap details taker/payment ID namings and 0x prefix to ERC-20 URL

### DIFF
--- a/atomic_qt_design/qml/Constants/General.qml
+++ b/atomic_qt_design/qml/Constants/General.qml
@@ -32,10 +32,11 @@ QtObject {
     readonly property var reg_pass_special: /(?=.*[@#$%{}[\]()\/\\'"`~,;:.<>+\-_=!^&*|?])/
     readonly property var reg_pass_count: /(?=.{16,})/
 
-    function viewTxAtExplorer(ticker, id) {
+    function viewTxAtExplorer(ticker, id, add_0x=false) {
         if(id !== '') {
             const coin_info = API.get().get_coin_info(ticker)
-            Qt.openUrlExternally(coin_info.explorer_url + 'tx/' + id)
+            const id_prefix = add_0x && coin_info.type === 'ERC-20' ? '0x' : ''
+            Qt.openUrlExternally(coin_info.explorer_url + 'tx/' + id_prefix + id)
         }
     }
 

--- a/atomic_qt_design/qml/Constants/General.qml
+++ b/atomic_qt_design/qml/Constants/General.qml
@@ -32,6 +32,13 @@ QtObject {
     readonly property var reg_pass_special: /(?=.*[@#$%{}[\]()\/\\'"`~,;:.<>+\-_=!^&*|?])/
     readonly property var reg_pass_count: /(?=.{16,})/
 
+    function viewTxAtExplorer(ticker, id) {
+        if(id !== '') {
+            const coin_info = API.get().get_coin_info(ticker)
+            Qt.openUrlExternally(coin_info.explorer_url + 'tx/' + id)
+        }
+    }
+
     function diffPrefix(received) {
         return received === "" ? "" : received === true ? "+ " :  "- "
     }

--- a/atomic_qt_design/qml/Exchange/OrderModal.qml
+++ b/atomic_qt_design/qml/Exchange/OrderModal.qml
@@ -89,16 +89,16 @@ DefaultModal {
             visible: text !== ''
         }
 
-        // Maker Payment ID
+        // Payment ID
         TextWithTitle {
-            title: API.get().empty_string + (qsTr("Maker Payment ID"))
+            title: API.get().empty_string + (details.am_i_maker ? qsTr("Maker Payment Sent ID") : qsTr("Maker Payment Spent ID"))
             text: API.get().empty_string + (getSwapPaymentID(details, false))
             visible: text !== ''
         }
 
-        // Taker Payment ID
+        // Payment ID
         TextWithTitle {
-            title: API.get().empty_string + (qsTr("Taker Payment ID"))
+            title: API.get().empty_string + (details.am_i_maker ? qsTr("Taker Payment Spent ID") : qsTr("Taker Payment Sent ID"))
             text: API.get().empty_string + (getSwapPaymentID(details, true))
             visible: text !== ''
         }

--- a/atomic_qt_design/qml/Exchange/OrderModal.qml
+++ b/atomic_qt_design/qml/Exchange/OrderModal.qml
@@ -143,8 +143,8 @@ DefaultModal {
                 onClicked: {
                     const maker_id = getSwapPaymentID(details, false)
                     const taker_id = getSwapPaymentID(details, true)
-                    if(maker_id !== '') Qt.openUrlExternally(API.get().get_coin_info(details.maker_coin).explorer_url + "tx/" + maker_id)
-                    if(taker_id !== '') Qt.openUrlExternally(API.get().get_coin_info(details.taker_coin).explorer_url + "tx/" + taker_id)
+                    if(maker_id !== '') General.viewTxAtExplorer(details.maker_coin, maker_id)
+                    if(taker_id !== '') General.viewTxAtExplorer(details.taker_coin, taker_id)
                 }
             }
         }

--- a/atomic_qt_design/qml/Exchange/OrderModal.qml
+++ b/atomic_qt_design/qml/Exchange/OrderModal.qml
@@ -143,8 +143,8 @@ DefaultModal {
                 onClicked: {
                     const maker_id = getSwapPaymentID(details, false)
                     const taker_id = getSwapPaymentID(details, true)
-                    if(maker_id !== '') General.viewTxAtExplorer(details.maker_coin, maker_id)
-                    if(taker_id !== '') General.viewTxAtExplorer(details.taker_coin, taker_id)
+                    if(maker_id !== '') General.viewTxAtExplorer(details.maker_coin, maker_id, true)
+                    if(taker_id !== '') General.viewTxAtExplorer(details.taker_coin, taker_id, true)
                 }
             }
         }

--- a/atomic_qt_design/qml/Wallet/SendResult.qml
+++ b/atomic_qt_design/qml/Wallet/SendResult.qml
@@ -58,7 +58,7 @@ ColumnLayout {
         PrimaryButton {
             text: API.get().empty_string + (qsTr("View at Explorer"))
             Layout.fillWidth: true
-            onClicked: Qt.openUrlExternally(result.explorer_url + "tx/" + tx_hash.text)
+            onClicked: General.viewTxAtExplorer(API.get().current_coin_info.ticker, tx_hash.text)
         }
     }
 }

--- a/atomic_qt_design/qml/Wallet/TransactionDetailsModal.qml
+++ b/atomic_qt_design/qml/Wallet/TransactionDetailsModal.qml
@@ -78,7 +78,7 @@ DefaultModal {
             PrimaryButton {
                 text: API.get().empty_string + (qsTr("View at Explorer"))
                 Layout.fillWidth: true
-                onClicked: Qt.openUrlExternally(API.get().current_coin_info.explorer_url + "tx/" + details.tx_hash)
+                onClicked: General.viewTxAtExplorer(API.get().current_coin_info.ticker, details.tx_hash)
             }
         }
     }


### PR DESCRIPTION
Fixing: https://github.com/KomodoPlatform/atomicDEX-Pro/issues/246

    "Maker Payment ID" is actually the txid of "Taker Payment"
    "Taker Payment ID" is actually the txid of "Maker Payment Spent"
    the link to erc20 blockexplorer does not work because txids on etherscan start with 0x

@cipig Can you please test this?
