### PR TITLE
Fix transactions list width error

### DIFF
--- a/atomic_qt_design/qml/Wallet/Transactions.qml
+++ b/atomic_qt_design/qml/Wallet/Transactions.qml
@@ -7,6 +7,7 @@ import "../Constants"
 
 // List
 ListView {
+    id: list
     ScrollBar.vertical: ScrollBar {}
     implicitWidth: contentItem.childrenRect.width
     implicitHeight: contentItem.childrenRect.height
@@ -25,7 +26,7 @@ ListView {
     // Row
     delegate: Rectangle {
         id: rectangle
-        implicitWidth: parent.width
+        implicitWidth: list.width
         height: 65
 
         property bool hovered: false


### PR DESCRIPTION
Fixing this error:
`qrc:/atomic_qt_design/qml/Wallet/Transactions.qml:28: TypeError: Cannot read property 'width' of null                   qrc:/atomic_qt_design/qml/Wallet/Transactions.qml:28: TypeError: Cannot read property 'width' of null                   qrc:/atomic_qt_design/qml/Wallet/Transactions.qml:28: TypeError: Cannot read property 'width' of null`

Main goal is to fix https://github.com/KomodoPlatform/atomicDEX-Pro/issues/273 so that needs testing @tonymorony 