### PR TITLE
Candlestick chart cursor precision and default timescale

### DIFF
--- a/atomic_qt_design/qml/Constants/General.qml
+++ b/atomic_qt_design/qml/Constants/General.qml
@@ -105,9 +105,17 @@ QtObject {
 
     readonly property int amountPrecision: 8
     readonly property int sliderDigitLimit: 9
-    
+    readonly property int recommendedPrecision: -1337
+
+    function getRecommendedPrecision(v) {
+        return Math.min(Math.max(sliderDigitLimit - v.toString().split(".")[0].length, 0), amountPrecision)
+    }
+
     function formatDouble(v, precision) {
+        if(precision === recommendedPrecision) precision = getRecommendedPrecision(v)
+
         if(precision === 0) return parseInt(v).toString()
+
         // Remove more than n decimals, then convert to string without trailing zeros
         return parseFloat(v).toFixed(precision || amountPrecision).replace(/\.?0+$/,"")
     }

--- a/atomic_qt_design/qml/Exchange/Trade/CandleStickChart.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/CandleStickChart.qml
@@ -389,6 +389,7 @@ ChartView {
         flat: true
         font.pixelSize: Style.textSizeSmall3
 
+        currentIndex: 5 // 1h
         model: General.chart_times
 
         property bool initialized: false

--- a/atomic_qt_design/qml/Exchange/Trade/CandleStickChart.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/CandleStickChart.qml
@@ -252,13 +252,13 @@ ChartView {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
 
-            width: 30
+            width: Math.max(value_y_text.width, 30)
             height: value_y_text.height
             DefaultText {
                 id: value_y_text
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
-                text_value: General.formatDouble(series.last_value, 0)
+                text_value: General.formatDouble(series.last_value, General.recommendedPrecision)
                 font.pixelSize: series.axisYRight.labelsFont.pixelSize
                 color: Style.colorChartLineText
             }
@@ -291,7 +291,7 @@ ChartView {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
 
-            width: 30
+            width: Math.max(cursor_y_text.width, 30)
             height: cursor_y_text.height
             DefaultText {
                 id: cursor_y_text
@@ -485,7 +485,7 @@ ChartView {
 
                 // Texts
                 cursor_x_text.text_value = realDataFound ? General.timestampToDate(realData.timestamp).toString() : ""
-                cursor_y_text.text_value = General.formatDouble(cp.y, 0)
+                cursor_y_text.text_value = General.formatDouble(cp.y, General.recommendedPrecision)
 
                 const highlightColor = realDataFound && realData.close >= realData.open ? Style.colorGreen : Style.colorRed
                 cursor_values.text_value = realDataFound ? (

--- a/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
@@ -331,7 +331,7 @@ FloatingBackground {
                 enabled: input_volume.field.enabled
                 property bool updating_from_text_field: false
                 property bool updating_text_field: false
-                readonly property int precision: Math.max(0, Math.min(General.amountPrecision, General.sliderDigitLimit - to.toString().split(".")[0].length))
+                readonly property int precision: General.getRecommendedPrecision(to)
                 visible: my_side
                 Layout.fillWidth: true
                 Layout.leftMargin: top_line.Layout.leftMargin


### PR DESCRIPTION
- Fixed cursor value precision was 0, now it's adaptive to the digit count, maximum of 9 digits.
- Default chart timescale is now 1h

I'm on mobile data, I could not test it at real build.

Solving https://github.com/KomodoPlatform/atomicDEX-Pro/issues/347