### PR TITLE
Prioritize KMD/BTC coins at DEX

### DIFF
--- a/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
@@ -76,9 +76,9 @@ FloatingBackground {
             coins = coins.filter(c => c !== filter_ticker)
 
         // Prioritize KMD / BTC pair
-        const prioritized_1 = my_side ? "KMD" : "BTC"
+        const prioritized_1 = "KMD"
         if(coins.indexOf(prioritized_1) !== -1) return prioritized_1
-        const prioritized_2 = my_side ? "BTC" : "KMD"
+        const prioritized_2 = "BTC"
         if(coins.indexOf(prioritized_2) !== -1) return prioritized_2
 
         // Pick a random one if prioritized ones do not satisfy

--- a/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
@@ -127,7 +127,7 @@ FloatingBackground {
         if(coin === undefined) {
             // If there are other coins, select first
             if(coins.length > 0) {
-                combo.currentIndex = 0
+                setAnyTicker()
                 return coins[combo.currentIndex].ticker
             }
             // If there isn't any, reset index

--- a/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
@@ -75,12 +75,6 @@ FloatingBackground {
         if(filter_ticker !== undefined || filter_ticker !== '')
             coins = coins.filter(c => c !== filter_ticker)
 
-        // Prioritize KMD / BTC pair
-        const prioritized_1 = "KMD"
-        if(coins.indexOf(prioritized_1) !== -1) return prioritized_1
-        const prioritized_2 = "BTC"
-        if(coins.indexOf(prioritized_2) !== -1) return prioritized_2
-
         // Pick a random one if prioritized ones do not satisfy
         return coins.length > 0 ? coins[0] : ''
     }
@@ -127,7 +121,7 @@ FloatingBackground {
         if(coin === undefined) {
             // If there are other coins, select first
             if(coins.length > 0) {
-                setAnyTicker()
+                combo.currentIndex = 0
                 return coins[combo.currentIndex].ticker
             }
             // If there isn't any, reset index
@@ -253,10 +247,6 @@ FloatingBackground {
                     Layout.fillWidth: true
 
                     model: ticker_list
-
-                    onModelChanged: {
-                        if(ticker_list.length > 0) setAnyTicker()
-                    }
 
                     onCurrentTextChanged: {
                         if(!recursive_update) {

--- a/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/OrderForm.qml
@@ -57,7 +57,7 @@ FloatingBackground {
     }
 
     function canShowFees() {
-        return my_side && valid_trade_info && !General.isZero(getVolume()) 
+        return my_side && valid_trade_info && !General.isZero(getVolume())
     }
 
     function getVolume() {
@@ -69,10 +69,20 @@ FloatingBackground {
     }
 
     function getAnyAvailableCoin(filter_ticker) {
-        let coins = getFilteredCoins()
+        let coins = getFilteredCoins().map(c => c.ticker)
+
+        // Filter out ticker
         if(filter_ticker !== undefined || filter_ticker !== '')
-            coins = coins.filter(c => c.ticker !== filter_ticker)
-        return coins.length > 0 ? coins[0].ticker : ''
+            coins = coins.filter(c => c !== filter_ticker)
+
+        // Prioritize KMD / BTC pair
+        const prioritized_1 = my_side ? "KMD" : "BTC"
+        if(coins.indexOf(prioritized_1) !== -1) return prioritized_1
+        const prioritized_2 = my_side ? "BTC" : "KMD"
+        if(coins.indexOf(prioritized_2) !== -1) return prioritized_2
+
+        // Pick a random one if prioritized ones do not satisfy
+        return coins.length > 0 ? coins[0] : ''
     }
 
     function fieldsAreFilled() {
@@ -243,6 +253,11 @@ FloatingBackground {
                     Layout.fillWidth: true
 
                     model: ticker_list
+
+                    onModelChanged: {
+                        if(ticker_list.length > 0) setAnyTicker()
+                    }
+
                     onCurrentTextChanged: {
                         if(!recursive_update) {
                             resetTradeInfo()

--- a/atomic_qt_design/qml/Exchange/Trade/Trade.qml
+++ b/atomic_qt_design/qml/Exchange/Trade/Trade.qml
@@ -235,8 +235,22 @@ Item {
         return cb === undefined ? [] : cb
     }
 
+    function moveToBeginning(coins, ticker) {
+        const idx = coins.map(c => c.ticker).indexOf(ticker)
+        if(idx === -1) return
+
+        const coin = coins[idx]
+        return [coin].concat(coins.filter(c => c.ticker !== ticker))
+    }
+
     function getCoins(my_side) {
-        const coins = API.get().enabled_coins
+        let coins = API.get().enabled_coins
+
+        // Prioritize KMD / BTC pair by moving them to the start
+        coins = moveToBeginning(coins, "BTC")
+        coins = moveToBeginning(coins, "KMD")
+
+        // Return full list
         if(my_side === undefined) return coins
 
         // Filter for Sell


### PR DESCRIPTION
With our current DEX ticker `ComboBox` model is automatically choosing the first one at the list. 

This change detects the model reset and checks if `KMD` is available, chooses that, if not, chooses `BTC`.

Normally, changing `Sell/Base`coin resets the `Receive/Rel` coin, and the alphabetically first coin in the list is being selected. This is still same, but now `Rel` side becomes `KMD` in this situation. Unless `Base` side is `KMD`, in that case, `Rel` side becomes `BTC`. 

Please check for QML errors which would look like ` qrc:/atomic_qt_design/qml/Constants/API.qml:0: RangeError: Maximum call stack size exceeded.`
