### PR TITLE
fix build instructions link to newer one

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Get Started
 
-Follow the OS specific [build instructions](https://github.com/KomodoPlatform/atomicDEX-Pro/tree/master/ci_tools_atomic_dex#linux-quickstart) if you know what you are doing.
+Follow the OS specific [build instructions](https://github.com/KomodoPlatform/atomicDEX-Pro/blob/dev/ci_tools_atomic_dex/README.md) if you know what you are doing.
 
 You can [download](https://github.com/KomodoPlatform/atomicDEX-Pro/releases) the pre-built <b>alpha</b> binaries on our [github release page](https://github.com/KomodoPlatform/atomicDEX-Pro/releases).
 


### PR DESCRIPTION
Main readme links to old build instructions on the master branch, hence took the liberty to update it to a newer file which is on dev.