### PR TITLE
DEX Privacy and Linux BTC Symbol

### DIFF
--- a/atomic_qt_design/qml/Components/DefaultText.qml
+++ b/atomic_qt_design/qml/Components/DefaultText.qml
@@ -11,7 +11,7 @@ Text {
     font.family: Style.font_family
     font.pixelSize: Style.textSize
     color: Style.colorText
-    text: privacy && General.privacy_mode ? "*****" : text_value
+    text: privacy && General.privacy_mode ? General.privacy_text : text_value
     wrapMode: Text.WordWrap
 }
 

--- a/atomic_qt_design/qml/Constants/API.qml
+++ b/atomic_qt_design/qml/Constants/API.qml
@@ -291,8 +291,6 @@ QtObject {
 
         find_closest_ohlc_data: () => { return {"close":0.0000654,"high":0.0000655,"low":0.0000654,"open":0.0000655,"quote_volume":0.006986865,"timestamp":1593740820,"volume":106.83} },
 
-        get_ohlc_data: (range) => [{"close":0.0000654,"high":0.0000655,"low":0.0000654,"open":0.0000655,"quote_volume":0.006986865,"timestamp":1593740820,"volume":106.83},{"close":0.0000653,"high":0.0000653,"low":0.0000653,"open":0.0000653,"quote_volume":0.0068565,"timestamp":1593740880,"volume":105},{"close":0.0000653,"high":0.0000653,"low":0.0000653,"open":0.0000653,"quote_volume":0.007420692,"timestamp":1593741000,"volume":113.64}],
-
         get_wallets: () => { return ["naezith", "slyris", "ca333", "tony"] },
 
         get_trade_infos: (ticker, receive_ticker, amount) => {

--- a/atomic_qt_design/qml/Constants/General.qml
+++ b/atomic_qt_design/qml/Constants/General.qml
@@ -16,6 +16,7 @@ QtObject {
     readonly property string cex_icon: 'ⓘ'
     readonly property string download_icon: '📥'
     readonly property string right_arrow_icon: "⮕"
+    readonly property string privacy_text: "*****"
 
     property bool privacy_mode: false
 
@@ -165,8 +166,10 @@ QtObject {
     }
 
     function getTickersAndBalances(coins) {
+        const privacy_on = General.privacy_mode
+        const privacy_text = General.privacy_text
         return coins.map(c => {
-            return { value: c.ticker, text: c.ticker + " (" + c.balance + ")" }
+            return { value: c.ticker, text: c.ticker + " (" + (privacy_on ? privacy_text : c.balance) + ")" }
         })
     }
 

--- a/atomic_qt_design/qml/Constants/General.qml
+++ b/atomic_qt_design/qml/Constants/General.qml
@@ -100,7 +100,7 @@ QtObject {
         const symbols = {
             "USD": "$",
             "EUR": "€",
-            "BTC": "₿",
+            "BTC": Qt.platform.os === 'linux' ? "฿" : "₿",
             "KMD": "KMD",
         }
 


### PR DESCRIPTION
- Ubuntu is not able to show ₿ so Linux build uses ฿ instead.
- Privacy filter for DEX Sell coins list

![image](https://user-images.githubusercontent.com/6732486/88663210-e1a40d80-d0e3-11ea-847a-fa9e3dbe2397.png)
