### PR TITLE
Change auto wallet selection behaviour

### DIFF
--- a/atomic_qt_design/qml/App.qml
+++ b/atomic_qt_design/qml/App.qml
@@ -11,6 +11,8 @@ Rectangle {
 
     color: Style.colorTheme8
 
+    property string selected_wallet_name: ""
+
     function firstPage() {
         return !API.get().first_run() && API.get().is_there_a_default_wallet() ? idx_login : idx_first_launch
     }
@@ -21,7 +23,8 @@ Rectangle {
 
     function onDisconnect() { openFirstLaunch() }
 
-    function openFirstLaunch(force) {        
+    function openFirstLaunch(force=false, set_wallet_name=true) {
+        if(set_wallet_name) selected_wallet_name = API.get().wallet_default_name
         cleanApp()
 
         if(API.design_editor) {
@@ -70,13 +73,13 @@ Rectangle {
 
         RecoverSeed {
             onClickedBack: () => { openFirstLaunch() }
-            postConfirmSuccess: () => { openFirstLaunch() }
+            postConfirmSuccess: () => { openFirstLaunch(false, false) }
         }
 
         NewUser {
             id: new_user
             onClickedBack: () => { openFirstLaunch() }
-            postCreateSuccess: () => { openFirstLaunch() }
+            postCreateSuccess: () => { openFirstLaunch(false, false) }
         }
 
         Login {

--- a/atomic_qt_design/qml/App.qml
+++ b/atomic_qt_design/qml/App.qml
@@ -14,7 +14,7 @@ Rectangle {
     property string selected_wallet_name: ""
 
     function firstPage() {
-        return !API.get().first_run() && API.get().is_there_a_default_wallet() ? idx_login : idx_first_launch
+        return !API.get().first_run() && selected_wallet_name !== "" ? idx_login : idx_first_launch
     }
 
     function cleanApp() {

--- a/atomic_qt_design/qml/Screens/FirstLaunch.qml
+++ b/atomic_qt_design/qml/Screens/FirstLaunch.qml
@@ -88,7 +88,7 @@ SetupPage {
                             anchors.fill: parent
                             hoverEnabled: true
                             onClicked: {
-                                API.get().wallet_default_name = model.modelData
+                                selected_wallet_name = model.modelData
                                 onClickedWallet()
                             }
                         }

--- a/atomic_qt_design/qml/Screens/Login.qml
+++ b/atomic_qt_design/qml/Screens/Login.qml
@@ -72,7 +72,6 @@ SetupPage {
                 text: API.get().empty_string + (qsTr("Back"))
                 Layout.fillWidth: true
                 onClicked: {
-                    selected_wallet_name = ""
                     reset()
                     onClickedBack()
                 }

--- a/atomic_qt_design/qml/Screens/Login.qml
+++ b/atomic_qt_design/qml/Screens/Login.qml
@@ -17,7 +17,7 @@ SetupPage {
     }
 
     function onClickedLogin(password) {
-        if(API.get().login(password, API.get().wallet_default_name)) {
+        if(API.get().login(password, selected_wallet_name)) {
             console.log("Success: Login")
             postLoginSuccess()
             return true
@@ -52,7 +52,7 @@ SetupPage {
         width: 400
 
         DefaultText {
-            text_value: API.get().empty_string + (qsTr("Login") + ": " + API.get().wallet_default_name)
+            text_value: API.get().empty_string + (qsTr("Login") + ": " + selected_wallet_name)
         }
 
         HorizontalLine {
@@ -72,7 +72,7 @@ SetupPage {
                 text: API.get().empty_string + (qsTr("Back"))
                 Layout.fillWidth: true
                 onClicked: {
-                    API.get().wallet_default_name = ""
+                    selected_wallet_name = ""
                     reset()
                     onClickedBack()
                 }

--- a/atomic_qt_design/qml/Screens/NewUser.qml
+++ b/atomic_qt_design/qml/Screens/NewUser.qml
@@ -77,6 +77,7 @@ SetupPage {
     function onClickedCreate(password, generated_seed, wallet_name) {
         if(API.get().create(password, generated_seed, wallet_name)) {
             console.log("Success: Create wallet")
+            selected_wallet_name = wallet_name
             postCreateSuccess()
             return true
         }

--- a/atomic_qt_design/qml/Screens/RecoverSeed.qml
+++ b/atomic_qt_design/qml/Screens/RecoverSeed.qml
@@ -19,6 +19,7 @@ SetupPage {
     function onClickedConfirm(password, seed, wallet_name) {
         if(API.get().create(password, seed, wallet_name)) {
             console.log("Success: Recover seed")
+            selected_wallet_name = wallet_name
             postConfirmSuccess()
             return true
         }

--- a/src/atomic.dex.app.cpp
+++ b/src/atomic.dex.app.cpp
@@ -1387,8 +1387,14 @@ namespace atomic_dex
     bool
     application::login(const QString& password, const QString& wallet_name)
     {
-        bool res = m_wallet_manager.login(password, wallet_name, get_mm2(), [this]() { this->set_status("initializing_mm2"); });
-        this->m_addressbook->initializeFromCfg();
+        bool res = m_wallet_manager.login(password, wallet_name, get_mm2(), [this, &wallet_name]() {
+            this->set_wallet_default_name(wallet_name);
+            this->set_status("initializing_mm2");
+        });
+        if (res)
+        {
+            this->m_addressbook->initializeFromCfg();
+        }
         return res;
     }
 

--- a/src/atomic.dex.app.cpp
+++ b/src/atomic.dex.app.cpp
@@ -878,6 +878,7 @@ namespace atomic_dex
 
         this->m_need_a_full_refresh_of_mm2 = true;
 
+        this->m_wallet_manager.just_set_wallet_name("");
         return fs::remove(get_atomic_dex_config_folder() / "default.wallet");
     }
 

--- a/src/atomic.dex.app.cpp
+++ b/src/atomic.dex.app.cpp
@@ -879,6 +879,7 @@ namespace atomic_dex
         this->m_need_a_full_refresh_of_mm2 = true;
 
         this->m_wallet_manager.just_set_wallet_name("");
+        emit on_wallet_default_name_changed();
         return fs::remove(get_atomic_dex_config_folder() / "default.wallet");
     }
 

--- a/src/atomic.dex.qt.wallet.manager.cpp
+++ b/src/atomic.dex.qt.wallet.manager.cpp
@@ -84,7 +84,7 @@ namespace atomic_dex
             std::ofstream ofs((get_atomic_dex_config_folder() / "default.wallet"s).string().c_str());
             ofs << wallet_name.toStdString();
 
-            set_wallet_default_name(wallet_name);
+            //set_wallet_default_name(wallet_name);
 
             std::ofstream  wallet_object(wallet_object_path.string());
             nlohmann::json wallet_object_json;

--- a/src/atomic.dex.qt.wallet.manager.cpp
+++ b/src/atomic.dex.qt.wallet.manager.cpp
@@ -313,4 +313,10 @@ namespace atomic_dex
     {
         return m_wallet_cfg;
     }
+
+    void
+    qt_wallet_manager::just_set_wallet_name(QString wallet_name)
+    {
+        this->m_current_default_wallet = wallet_name;
+    }
 } // namespace atomic_dex

--- a/src/atomic.dex.qt.wallet.manager.hpp
+++ b/src/atomic.dex.qt.wallet.manager.hpp
@@ -35,6 +35,7 @@ namespace atomic_dex
     {
       public:
         QString get_wallet_default_name() const noexcept;
+        void just_set_wallet_name(QString wallet_name);
 
         void set_wallet_default_name(QString wallet_name) noexcept;
 


### PR DESCRIPTION
Before, after chain creation or after selecting a wallet, default wallet was being set and app was opening with the login page of that wallet. Now it opens to the welcome page.